### PR TITLE
Fix for Clothes

### DIFF
--- a/Modules/Core/Inventory/Client/Events.lua
+++ b/Modules/Core/Inventory/Client/Events.lua
@@ -121,7 +121,7 @@ AddEventHandler("Inventory:UpdatePlayerInventory", function(Data)
         SendNUIMessage({
             Type = "UpdateInventory",
             Inventory = Inventory.PlayerItems,
-            MaxWeight = 32.0
+            MaxWeight = GlobalConfig.PlayerWeight
         })
     end
 end)

--- a/Root/Client/Functions.lua
+++ b/Root/Client/Functions.lua
@@ -18,6 +18,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 0) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -28,6 +29,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 1) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -38,6 +40,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 2) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -48,6 +51,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 6) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -58,6 +62,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 7) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -68,6 +73,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 1) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -78,6 +84,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 7) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -88,6 +95,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 11) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -98,6 +106,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 3) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -108,6 +117,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 9) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -118,6 +128,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 5) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -128,6 +139,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 4) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -138,6 +150,7 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 6) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
+                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end

--- a/Root/Client/Functions.lua
+++ b/Root/Client/Functions.lua
@@ -18,7 +18,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 0) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -29,7 +28,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 1) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -40,7 +38,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 2) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -51,7 +48,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 6) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -62,7 +58,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedPropIndex(PlayerPedId(), 7) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -73,7 +68,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 1) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -84,7 +78,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 7) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -95,7 +88,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 11) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -106,7 +98,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 3) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -117,7 +108,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 9) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -128,7 +118,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 5) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -139,7 +128,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 4) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end
@@ -150,7 +138,6 @@ Register.Clothes = function(Item, Sex, Component, DrawableId)
                 if GetPedDrawableVariation(PlayerPedId(), 6) == DrawableId then
                     Skin.DeleteClothes(Component)
                 else
-                    Skin.DeleteClothes(Component)
                     Skin.SetClothes(Sex, Component, DrawableId)
                 end
             end


### PR DESCRIPTION
This fixes clothes showing up decals on different clothes when changing, replicable by using Police Shirt and then Unemployed Shirt, the decals remain after equipping the other shirt.

This way it removes the type of clothes you might have equipped and unequips them, then equips the other one.

Also removed a hardcoded max player weight.